### PR TITLE
Updates sinatra gem (from 1.4.4 to 1.4.8)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,14 +13,14 @@ GEM
       method_source (~> 0.8)
       slop (~> 3.4)
     rack (1.5.5)
-    rack-protection (1.5.2)
+    rack-protection (1.5.3)
       rack
-    sinatra (1.4.4)
-      rack (~> 1.4)
+    sinatra (1.4.8)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     slop (3.4.6)
-    tilt (1.4.1)
+    tilt (2.0.8)
     timeout_cache (0.0.2)
 
 PLATFORMS


### PR DESCRIPTION
- gets rid of a deprecation warning in server log